### PR TITLE
Prepare release 0.9.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+python-cloud-info-provider (0.9.1-1) xenial; urgency=medium
+
+  [ Enold Fernandez ]
+  * OCCI is optional, do not fail if no OCCI endpoint is present.
+
+  [ Baptiste Grenier ]
+  * Updated organization name in documentation
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Mon, 30 Apr 2018 10:51:03 +0200
+
 python-cloud-info-provider (0.9.0-1) xenial; urgency=medium
 
   [ Alvaro Lopez ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 python-cloud-info-provider (0.9.1-1) xenial; urgency=medium
 
-  [ Enold Fernandez ]
+  [ Enol Fernandez ]
   * OCCI is optional, do not fail if no OCCI endpoint is present.
 
   [ Baptiste Grenier ]

--- a/rpm/cloud-info-provider.spec
+++ b/rpm/cloud-info-provider.spec
@@ -6,7 +6,7 @@
 
 Summary: Information provider for Cloud Compute and Cloud Storage services for BDII
 Name: cloud-info-provider
-Version: 0.9.0
+Version: 0.9.1
 Release: 1%{?dist}
 Group: Applications/Internet
 License: ASL 2.0
@@ -57,6 +57,9 @@ rm -rf $RPM_BUILD_ROOT
 %config /etc/cloud-info-provider/
 
 %changelog
+* Mon Apr 30 2018 Baptiste Grenier <baptiste.grenier@egi.eu> 0.9.1
+- OCCI is optional, do not fail if no OCCI endpoint is present (Enol Fernandez)
+- Update organization name in documentation (Baptiste Grenier)
 * Fri Mar 30 2018 Baptiste Grenier <baptiste.grenier@egi.eu> 0.9.0
 - Use keystoneauth and v3 API, deprecate v2.0 API (Alvaro Lopez)
 - Fix entry updates for ApplicationEnvironment (Boris Parak)


### PR DESCRIPTION
Release 0.9.1
- OCCI is optional, do not fail if no OCCI endpoint is present (Enol Fernandez)
- Update organization name in documentation (Baptiste Grenier)