### PR TITLE
Fix retrieval of fields from the template for tests.

### DIFF
--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -104,13 +104,27 @@ class OpenStackProviderTest(base.TestCase):
                               templates,
                               template="compute.ldif",
                               ignored_fields=[
+                                  "compute_api_type",
+                                  "compute_api_version",
+                                  "compute_api_endpoint_technology",
+                                  "compute_capabilities",
+                                  "compute_endpoint_url",
+                                  "compute_hypervisor",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware",
+                                  "compute_middleware_developer",
+                                  "compute_middleware_version",
+                                  "compute_production_level",
+                                  "compute_api_authn_method",
                                   "compute_service_name",
+                                  "compute_service_production_level",
+                                  "compute_total_cores",
+                                  "compute_total_ram",
+                                  "image_id",
                                   "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version"
+                                  "image_version",
+                                  "image_description",
+                                  "image_marketplace_id"
                               ])
 
     def test_get_legacy_templates_with_defaults_from_static(self):
@@ -147,13 +161,27 @@ class OpenStackProviderTest(base.TestCase):
                               templates,
                               template="compute.ldif",
                               ignored_fields=[
+                                  "compute_api_type",
+                                  "compute_api_version",
+                                  "compute_api_endpoint_technology",
+                                  "compute_capabilities",
+                                  "compute_endpoint_url",
+                                  "compute_hypervisor",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware",
+                                  "compute_middleware_developer",
+                                  "compute_middleware_version",
+                                  "compute_production_level",
+                                  "compute_api_authn_method",
                                   "compute_service_name",
+                                  "compute_service_production_level",
+                                  "compute_total_cores",
+                                  "compute_total_ram",
+                                  "image_id",
                                   "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version"
+                                  "image_version",
+                                  "image_description",
+                                  "image_marketplace_id"
                               ])
 
     def test_get_templates_with_defaults(self):
@@ -186,13 +214,27 @@ class OpenStackProviderTest(base.TestCase):
                               templates,
                               template="compute.ldif",
                               ignored_fields=[
+                                  "compute_api_type",
+                                  "compute_api_version",
+                                  "compute_api_endpoint_technology",
+                                  "compute_capabilities",
+                                  "compute_endpoint_url",
+                                  "compute_hypervisor",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware",
+                                  "compute_middleware_developer",
+                                  "compute_middleware_version",
+                                  "compute_production_level",
+                                  "compute_api_authn_method",
                                   "compute_service_name",
+                                  "compute_service_production_level",
+                                  "compute_total_cores",
+                                  "compute_total_ram",
+                                  "image_id",
                                   "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version"
+                                  "image_version",
+                                  "image_description",
+                                  "image_marketplace_id"
                               ])
 
     def test_get_templates_with_defaults_from_static(self):
@@ -227,13 +269,27 @@ class OpenStackProviderTest(base.TestCase):
                               templates,
                               template="compute.ldif",
                               ignored_fields=[
+                                  "compute_api_type",
+                                  "compute_api_version",
+                                  "compute_api_endpoint_technology",
+                                  "compute_capabilities",
+                                  "compute_endpoint_url",
+                                  "compute_hypervisor",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware",
+                                  "compute_middleware_developer",
+                                  "compute_middleware_version",
+                                  "compute_production_level",
+                                  "compute_api_authn_method",
                                   "compute_service_name",
+                                  "compute_service_production_level",
+                                  "compute_total_cores",
+                                  "compute_total_ram",
+                                  "image_id",
                                   "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version"
+                                  "image_version",
+                                  "image_description",
+                                  "image_marketplace_id"
                               ])
 
     @unittest.expectedFailure

--- a/cloud_info/tests/utils.py
+++ b/cloud_info/tests/utils.py
@@ -15,7 +15,9 @@ def get_variables_from_template(template, ignored_fields=[]):
     with open(template, "r") as f:
         content = f.read()
 
-    regexp = re.compile('%\((.+?)\)s')
+    # Look for variables names like
+    # ${static_compute_info['compute_service_production_level']}
+    regexp = re.compile('\${[^\[]+\[\'(.+?)\'\]}')
     l = set(regexp.findall(content))
     for k in itertools.chain(IGNORED_FIELDS, ignored_fields):
         if k in l:


### PR DESCRIPTION
In order to validate that fields used within the templates are correctly
populated by the OpenStack provider, they are extracted from the
templates.
With the switch to Mako the regex used to match them was obsoleted, this PR
fixes the regex and fixes the tests.