### PR TITLE
OpenStack provider: add a provider-specific argument to manage templates/flavors selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ cloud-info-provider-service --yaml-file /etc/cloud-info-provider/static.yaml \
 
 By default the OpenStack provider will return 'all' flavors, but it is also
 possible to select only 'public' or 'private' flavors using the
-`--select-flavors` parameter.
+`--select-flavors` parameter set to `all`, `public` or `private`.
 For more details see
 [OpenStack flavors documentation](https://docs.openstack.org/nova/pike/admin/flavors.html).
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ cd cloud-info-provider
 pip install .
 ```
 
-## Generation of the LDIF 
+## Usage
+
+### Generation of the LDIF
 
 By default the cloud-info-provider generates a LDIF according to the
 information in a yaml file describing the static information of the cloud
@@ -184,14 +186,24 @@ cloud-info-provider-service --yaml-file /etc/cloud-info-provider/static.yaml \
 
 **Test the generation of the LDIF before running the provider into your BDII!**
 
-### Legacy OpenStack OCCI-OS interface
+### OpenStack provider
+
+#### Filtering public or private flavors
+
+By default the OpenStack provider will return 'all' flavors, but it is also
+possible to select only 'public' or 'private' flavors using the
+`--select-flavors` parameter.
+For more details see
+[OpenStack flavors documentation](https://docs.openstack.org/nova/pike/admin/flavors.html).
+
+#### Legacy OpenStack OCCI-OS interface
 
 If you are using [OCCI-OS](https://github.com/EGI-FCTF/occi-os) for providing
 OCCI support for OpenStack, use the `legacy-occi-os` command line option. This
 will produce output with ids compatible with your setup instead of the current
 default that supports [ooi](https://launchpad.net/ooi).
 
-## Running the provider in a resource-BDII
+### Running the provider in a resource-BDII
 
 This is the normal deployment mode for the cloud provider. It should be installed
 in a node with access to your cloud infrastructure: for OpenStack, access to

--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -259,7 +259,17 @@ class OpenStackProvider(providers.BaseProvider):
                 ret['endpoints'][e_id] = e
         return ret
 
-    def get_templates(self):
+    def get_templates(self, filter='all'):
+        """Retrieve templates/flavors list
+
+        :param filter: Select 'public', 'private' or 'all' (default) templates.
+        :return: list of matching templates/flavors
+        :raises: OpenStackProviderException
+        """
+        if filter not in ['all', 'private', 'public']:
+            msg = ("Unsupported templates filter: '%s'" % filter)
+            raise exceptions.OpenStackProviderException(msg)
+
         flavors = {}
 
         defaults = {'template_platform': 'amd64',
@@ -269,7 +279,9 @@ class OpenStackProvider(providers.BaseProvider):
         flavor_id_attr = 'name' if self.legacy_occi_os else 'id'
         URI = 'http://schemas.openstack.org/template/'
         for flavor in self.nova.flavors.list(detailed=True):
-            if not flavor.is_public:
+            if filter == 'public' and not flavor.is_public:
+                continue
+            if filter == 'private' and flavor.is_public:
                 continue
 
             aux = defaults.copy()

--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -272,20 +272,20 @@ class OpenStackProvider(providers.BaseProvider):
         flavor_id_attr = 'name' if self.legacy_occi_os else 'id'
         URI = 'http://schemas.openstack.org/template/'
         for flavor in self.nova.flavors.list(detailed=True):
-            if self.select_flavors == 'public' and not flavor.is_public:
-                continue
-            if self.select_flavors == 'private' and flavor.is_public:
-                continue
-
-            aux = defaults.copy()
-            flavor_id = str(getattr(flavor, flavor_id_attr))
-            template_id = '%s%s#%s' % (URI, tpl_sch,
-                                       OpenStackProvider.occify(flavor_id))
-            aux.update({'template_id': template_id,
-                        'template_memory': flavor.ram,
-                        'template_cpu': flavor.vcpus,
-                        'template_disk': flavor.disk})
-            flavors[flavor.id] = aux
+            add_all = self.select_flavors == 'all'
+            add_pub = self.select_flavors == 'public' and flavor.is_public
+            add_priv = (self.select_flavors == 'private' and not
+                        flavor.is_public)
+            if add_all or add_pub or add_priv:
+                aux = defaults.copy()
+                flavor_id = str(getattr(flavor, flavor_id_attr))
+                template_id = '%s%s#%s' % (URI, tpl_sch,
+                                           OpenStackProvider.occify(flavor_id))
+                aux.update({'template_id': template_id,
+                            'template_memory': flavor.ram,
+                            'template_cpu': flavor.vcpus,
+                            'template_disk': flavor.disk})
+                flavors[flavor.id] = aux
         return flavors
 
     def get_images(self):

--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -76,9 +76,6 @@ class OpenStackProviderTest(base.TestCase):
         expected_templates = {}
         url = 'http://schemas.openstack.org/template/resource'
         for f in FAKES.flavors:
-            if not f.is_public:
-                continue
-
             name = f.name.strip().replace(' ', '_').replace('.', '-').lower()
             expected_templates[f.id] = {
                 'template_memory': f.ram,
@@ -131,9 +128,6 @@ class OpenStackProviderTest(base.TestCase):
         expected_templates = {}
         url = 'http://schemas.openstack.org/template/resource'
         for f in FAKES.flavors:
-            if not f.is_public:
-                continue
-
             name = f.name.strip().replace(' ', '_').replace('.', '-').lower()
             expected_templates[f.id] = {
                 'template_memory': f.ram,
@@ -188,9 +182,6 @@ class OpenStackProviderTest(base.TestCase):
         expected_templates = {}
         url = 'http://schemas.openstack.org/template/resource'
         for f in FAKES.flavors:
-            if not f.is_public:
-                continue
-
             expected_templates[f.id] = {
                 'template_memory': f.ram,
                 'template_cpu': f.vcpus,
@@ -241,9 +232,6 @@ class OpenStackProviderTest(base.TestCase):
         expected_templates = {}
         url = 'http://schemas.openstack.org/template/resource'
         for f in FAKES.flavors:
-            if not f.is_public:
-                continue
-
             expected_templates[f.id] = {
                 'template_memory': f.ram,
                 'template_cpu': f.vcpus,
@@ -297,7 +285,6 @@ class OpenStackProviderTest(base.TestCase):
         expected_templates = {}
         url = 'http://schemas.openstack.org/template/resource'
         for f in FAKES.flavors:
-
             expected_templates[f.id] = {
                 'template_memory': f.ram,
                 'template_cpu': f.vcpus,

--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -22,7 +22,8 @@ class OpenStackProviderOptionsTest(base.TestCase):
                                   '--os-auth-url', 'http://example.org:5000',
                                   '--os-cacert', 'foobar',
                                   '--insecure',
-                                  '--legacy-occi-os'])
+                                  '--legacy-occi-os',
+                                  '--select-flavors', 'public'])
 
         self.assertEqual(opts.os_username, 'foo')
         self.assertEqual(opts.os_password, 'bar')
@@ -30,6 +31,7 @@ class OpenStackProviderOptionsTest(base.TestCase):
         self.assertEqual(opts.os_cacert, 'foobar')
         self.assertEqual(opts.insecure, True)
         self.assertEqual(opts.legacy_occi_os, True)
+        self.assertEqual(opts.select_flavors, 'public')
 
 
 class OpenStackProviderTest(base.TestCase):
@@ -51,6 +53,7 @@ class OpenStackProviderTest(base.TestCase):
                 self.keystone_cert_issuer = "foo"
                 self.keystone_trusted_cas = []
                 self.insecure = False
+                self.select_flavors = 'all'
 
             def _get_endpoint_versions(*args, **kwargs):
                 return {
@@ -294,6 +297,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_disk': f.disk,
             }
 
+        self.provider.select_flavors = 'all'
         with utils.nested(
                 mock.patch.object(self.provider.static,
                                   'get_template_defaults'),
@@ -303,8 +307,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            filter = 'all'
-            templates = self.provider.get_templates(filter)
+            templates = self.provider.get_templates()
             assert m_get_template_defaults.called
 
         # Extract required fields from compute.ldif template excluding fields
@@ -354,6 +357,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_disk': f.disk,
             }
 
+        self.provider.select_flavors = 'public'
         with utils.nested(
                 mock.patch.object(self.provider.static,
                                   'get_template_defaults'),
@@ -363,8 +367,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            filter = 'public'
-            templates = self.provider.get_templates(filter)
+            templates = self.provider.get_templates()
             assert m_get_template_defaults.called
 
         # Extract required fields from compute.ldif template excluding fields
@@ -414,6 +417,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_disk': f.disk,
             }
 
+        self.provider.select_flavors = 'private'
         with utils.nested(
                 mock.patch.object(self.provider.static,
                                   'get_template_defaults'),
@@ -423,8 +427,7 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            filter = 'private'
-            templates = self.provider.get_templates(filter)
+            templates = self.provider.get_templates()
             assert m_get_template_defaults.called
 
         # Extract required fields from compute.ldif template excluding fields

--- a/cloud_info/tests/test_openstack.py
+++ b/cloud_info/tests/test_openstack.py
@@ -292,6 +292,184 @@ class OpenStackProviderTest(base.TestCase):
                                   "image_marketplace_id"
                               ])
 
+    def test_get_all_templates(self):
+        """Tests that all templates/flavors are returned"""
+        expected_templates = {}
+        url = 'http://schemas.openstack.org/template/resource'
+        for f in FAKES.flavors:
+
+            expected_templates[f.id] = {
+                'template_memory': f.ram,
+                'template_cpu': f.vcpus,
+                'template_id': '%s#%s' % (url, f.id),
+                'template_platform': 'i686',
+                'template_network': 'private',
+                'template_disk': f.disk,
+            }
+
+        with utils.nested(
+                mock.patch.object(self.provider.static,
+                                  'get_template_defaults'),
+                mock.patch.object(self.provider.nova.flavors, 'list'),
+        ) as (m_get_template_defaults, m_flavors_list):
+            m_get_template_defaults.return_value = {
+                'template_platform': 'i686'
+            }
+            m_flavors_list.return_value = FAKES.flavors
+            filter = 'all'
+            templates = self.provider.get_templates(filter)
+            assert m_get_template_defaults.called
+
+        # Extract required fields from compute.ldif template excluding fields
+        # extracted that are not related to the flavors
+        self.assert_resources(expected_templates,
+                              templates,
+                              template="compute.ldif",
+                              ignored_fields=[
+                                  "compute_service_name",
+                                  "compute_hypervisor",
+                                  "compute_api_authn_method",
+                                  "compute_total_ram",
+                                  "image_marketplace_id",
+                                  "compute_middleware_developer",
+                                  "compute_production_level",
+                                  "compute_production_level",
+                                  "compute_api_type",
+                                  "compute_api_endpoint_technology",
+                                  "compute_api_version",
+                                  "compute_endpoint_url",
+                                  "compute_service_production_level",
+                                  "compute_capabilities",
+                                  "compute_total_cores",
+                                  "compute_middleware",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware_version",
+                                  "image_description",
+                                  "image_id",
+                                  "image_name",
+                                  "image_version"
+                              ])
+
+    def test_get_public_templates(self):
+        """Tests that only public templates/flavors are returned"""
+        expected_templates = {}
+        url = 'http://schemas.openstack.org/template/resource'
+        for f in FAKES.flavors:
+            if not f.is_public:
+                continue
+
+            expected_templates[f.id] = {
+                'template_memory': f.ram,
+                'template_cpu': f.vcpus,
+                'template_id': '%s#%s' % (url, f.id),
+                'template_platform': 'i686',
+                'template_network': 'private',
+                'template_disk': f.disk,
+            }
+
+        with utils.nested(
+                mock.patch.object(self.provider.static,
+                                  'get_template_defaults'),
+                mock.patch.object(self.provider.nova.flavors, 'list'),
+        ) as (m_get_template_defaults, m_flavors_list):
+            m_get_template_defaults.return_value = {
+                'template_platform': 'i686'
+            }
+            m_flavors_list.return_value = FAKES.flavors
+            filter = 'public'
+            templates = self.provider.get_templates(filter)
+            assert m_get_template_defaults.called
+
+        # Extract required fields from compute.ldif template excluding fields
+        # extracted that are not related to the flavors
+        self.assert_resources(expected_templates,
+                              templates,
+                              template="compute.ldif",
+                              ignored_fields=[
+                                  "compute_service_name",
+                                  "compute_hypervisor",
+                                  "compute_api_authn_method",
+                                  "compute_total_ram",
+                                  "image_marketplace_id",
+                                  "compute_middleware_developer",
+                                  "compute_production_level",
+                                  "compute_production_level",
+                                  "compute_api_type",
+                                  "compute_api_endpoint_technology",
+                                  "compute_api_version",
+                                  "compute_endpoint_url",
+                                  "compute_service_production_level",
+                                  "compute_capabilities",
+                                  "compute_total_cores",
+                                  "compute_middleware",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware_version",
+                                  "image_description",
+                                  "image_id",
+                                  "image_name",
+                                  "image_version"
+                              ])
+
+    def test_get_private_templates(self):
+        """Tests that only private templates/flavors are returned"""
+        expected_templates = {}
+        url = 'http://schemas.openstack.org/template/resource'
+        for f in FAKES.flavors:
+            if f.is_public:
+                continue
+
+            expected_templates[f.id] = {
+                'template_memory': f.ram,
+                'template_cpu': f.vcpus,
+                'template_id': '%s#%s' % (url, f.id),
+                'template_platform': 'i686',
+                'template_network': 'private',
+                'template_disk': f.disk,
+            }
+
+        with utils.nested(
+                mock.patch.object(self.provider.static,
+                                  'get_template_defaults'),
+                mock.patch.object(self.provider.nova.flavors, 'list'),
+        ) as (m_get_template_defaults, m_flavors_list):
+            m_get_template_defaults.return_value = {
+                'template_platform': 'i686'
+            }
+            m_flavors_list.return_value = FAKES.flavors
+            filter = 'private'
+            templates = self.provider.get_templates(filter)
+            assert m_get_template_defaults.called
+
+        # Extract required fields from compute.ldif template excluding fields
+        # extracted that are not related to the flavors
+        self.assert_resources(expected_templates,
+                              templates,
+                              template="compute.ldif",
+                              ignored_fields=[
+                                  "compute_service_name",
+                                  "compute_hypervisor",
+                                  "compute_api_authn_method",
+                                  "compute_total_ram",
+                                  "image_marketplace_id",
+                                  "compute_middleware_developer",
+                                  "compute_production_level",
+                                  "compute_production_level",
+                                  "compute_api_type",
+                                  "compute_api_endpoint_technology",
+                                  "compute_api_version",
+                                  "compute_endpoint_url",
+                                  "compute_service_production_level",
+                                  "compute_capabilities",
+                                  "compute_total_cores",
+                                  "compute_middleware",
+                                  "compute_hypervisor_version",
+                                  "compute_middleware_version",
+                                  "image_description",
+                                  "image_id",
+                                  "image_name",
+                                  "image_version"
+                              ])
+
     @unittest.expectedFailure
     def test_get_images(self):
         # XXX move this to a custom class?


### PR DESCRIPTION
As documented on https://docs.openstack.org/nova/pike/admin/flavors.html :
a public flavor is a flavor that is not restricted to the current project.

Previously only public flavors were returned, it is now possible to select all
(default), public or private only flavors. Fix #82.