### PR TITLE
Update references to EGI-FCTF to point to EGI-Foundation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-cloud-info-provider
 Section: net
 Priority: extra
 Maintainer: EGI Federated Cloud <fedcloud-devel@mailman.egi.eu>
-Homepage: http://github.com/EGI-FCTF/cloud-info-provider
+Homepage: http://github.com/EGI-Federation/cloud-info-provider
 Build-Depends:
  debhelper (>= 7.0.50),
  dh-python,
@@ -12,7 +12,7 @@ Build-Depends-Indep:
  python-pbr (>= 0.6),
  python-setuptools
 Standards-Version: 3.9.6
-Vcs-Git: https://github.com/EGI-FCTF/cloud-info-provider.git
+Vcs-Git: https://github.com/EGI-Federation/cloud-info-provider.git
 
 Package: python-cloud-info-provider
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: cloud-info-provider
-Source: https://github.com/EGI-FCTF/BDIIscripts
+Source: https://github.com/EGI-Federation/cloud-info-provider
 
 Files: *
 Copyright: 2014 Salvatore Pinto, Álvaro Lopez,

--- a/rpm/cloud-info-provider.spec
+++ b/rpm/cloud-info-provider.spec
@@ -10,7 +10,7 @@ Version: 0.9.1
 Release: 1%{?dist}
 Group: Applications/Internet
 License: ASL 2.0
-URL: https://github.com/EGI-FCTF/cloud-info-provider
+URL: https://github.com/EGI-Federation/cloud-info-provider
 Source: cloud_info_provider-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)


### PR DESCRIPTION
As the repository was moved under the EGI-Foundation organisation it's appropriate to update references still present here and there.