### PR TITLE
Generates Jenkins cobertura report using a Tox environment.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,15 +28,6 @@ pipeline {
                 echo 'Computing unit testing coverage..'
                 sh 'tox -e cover'
 
-                echo 'Generating HTML report..'
-                publishHTML([allowMissing: false,
-                             alwaysLinkToLastBuild: false,
-                             keepAll: false,
-                             reportDir: 'cover',
-                             reportFiles: 'index.html',
-                             reportName: 'Coverage report',
-                             reportTitles: ''])
-
                 echo 'Generating Cobertura report..'
                 sh 'tox -e cobertura'
                 cobertura autoUpdateHealth: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,19 +38,7 @@ pipeline {
                              reportTitles: ''])
 
                 echo 'Generating Cobertura report..'
-                writeFile file: 'tox.ini.cobertura', text: '''[tox]
-envlist = cobertura
-[testenv]
-usedevelop = True
-install_command = pip install -U {opts} {packages}
-setenv =
-   VIRTUAL_ENV={envdir}
-deps = pytest-cov
-       nose
-       -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-commands = py.test --cov=cloud_info --cov-report=xml --cov-report=term-missing cloud_info/tests'''
-                sh 'tox -c tox.ini.cobertura'
+                sh 'tox -e cobertura'
                 cobertura autoUpdateHealth: false,
                           autoUpdateStability: false,
                           coberturaReportFile: '**/coverage.xml',

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,11 @@ commands = python setup.py testr --coverage --testr-args='{posargs}'
 deps = coveralls
        {[testenv]deps}
 
+[testenv:cobertura]
+deps = pytest-cov
+       -r{toxinidir}/test-requirements.txt
+commands = py.test --cov=cloud_info --cov-report=xml --cov-report=term-missing cloud_info/tests
+
 [testenv:docs]
 commands = python setup.py build_sphinx
 


### PR DESCRIPTION
<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 

Cobertura report was generated in Jenkinsfile using a temporary tox.ini.cobertura file. In order to keep Jenkins configuration cleaner, the report is created using a new Tox environment, called 'cobertura'. 

On the other hand, Jenkinsfile executes the 'cover' environment and was wrongly expecting a HTML report, thus marking the job as a failure. This latter part has been removed.

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue :**

<!-- Remove this if it is not relevant for your pull request -->
**Consider author for inclusion**:

- [ ] author list
- [ ] contributor list
