### PR TITLE
Split ooi and OpenStack providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ middleware information.
 Supported cloud middleware providers:
 
 * OpenNebula
-* OpenStack using Keystone authentication with API v3 *only*
+* OpenStack/ooi using Keystone authentication with API v3 *only*
 
 ## Installation
 
@@ -53,7 +53,7 @@ debs:
 * python-cloud-info-provider-opennebula
 * python-cloud-info-provider
 
-#### OpenStack provider dependencies
+#### OpenStack/ooi provider dependencies
 
 * python-novaclient
 * python-glanceclient
@@ -174,7 +174,7 @@ overriden with the `--yaml-file` option. A complete example with comments is
 available in the `sample.static.yaml` file.
 
 Dynamic information can be further obtained with the middleware providers
-(OpenStack and OpenNebula via rOCCI supported currently). Use the
+(OpenStack, ooi, and OpenNebula via rOCCI supported currently). Use the
 `--middleware` option for specifying the provider to use (see the command
 help for exact names). cloud-info-provider will fallback to static information
 defined in the yaml file if a dynamic provider is not able to return any
@@ -218,6 +218,9 @@ cloud-info-provider-service --yaml-file /etc/cloud-info-provider/static.yaml \
 
 ### OpenStack provider
 
+The OpenStack provider only publishes information about native OpenStack API access,
+for ooi information check below
+
 #### Filtering public or private flavors
 
 By default the OpenStack provider will return 'all' flavors, but it is also
@@ -226,17 +229,16 @@ possible to select only 'public' or 'private' flavors using the
 For more details see
 [OpenStack flavors documentation](https://docs.openstack.org/nova/pike/admin/flavors.html).
 
-#### Legacy OpenStack OCCI-OS interface
+### ooi provider
 
-If you are using [OCCI-OS](https://github.com/EGI-FCTF/occi-os) for providing
-OCCI support for OpenStack, use the `legacy-occi-os` command line option. This
-will produce output with ids compatible with your setup instead of the current
-default that supports [ooi](https://launchpad.net/ooi).
+The ooi provider publishes information for those sites using ooi on top of OpenStack
+nova to provide OCCI support. It has the same options as the openstack provider and yaml 
+configuration file can be used without any changes.
 
 ### Running the provider in a resource-BDII
 
 This is the normal deployment mode for the cloud provider. It should be installed
-in a node with access to your cloud infrastructure: for OpenStack, access to
+in a node with access to your cloud infrastructure: for OpenStack/ooi, access to
 nova service is needed; for OpenNebula-rOCCI provider, access to the files
 describing the rOCCI templates is needed (e.g. installing the provider in the same
 host as rOCCI-server).
@@ -271,6 +273,26 @@ and test it:
 ```
 
 It should output the full ldif describing your site.
+
+#### Publishing both native OpenStack and ooi information
+
+In your `/var/lib/bdii/gip/provider/cloud-info-provider` include calls to both OpenStack and ooi
+providers:
+
+```sh
+#!/bin/sh
+
+cloud-info-provider-service --yaml /etc/cloud-info-provider/openstack.yaml \
+                            --middleware openstack \
+                            --os-username <username> --os-password <password> \
+                            --os-user-domain-name default --os-project-name <tenant> \
+                            --os-project-domain-name default --os-auth-url <auth-url>
+cloud-info-provider-service --yaml /etc/cloud-info-provider/openstack.yaml \
+                            --middleware ooi \
+                            --os-username <username> --os-password <password> \
+                            --os-user-domain-name default --os-project-name <tenant> \
+                            --os-project-domain-name default --os-auth-url <auth-url>
+```
 
 ### Start the bdii service
 

--- a/cloud_info_provider/core.py
+++ b/cloud_info_provider/core.py
@@ -15,6 +15,7 @@ SUPPORTED_MIDDLEWARE = {
     'opennebularocci': 'cloud_info_provider.providers.opennebula.'
                        'OpenNebulaROCCIProvider',
     'static': 'cloud_info_provider.providers.static.StaticProvider',
+    'ooi': 'cloud_info_provider.providers.openstack.OoiProvider',
 }
 
 

--- a/cloud_info_provider/tests/data.py
+++ b/cloud_info_provider/tests/data.py
@@ -1,6 +1,5 @@
 import collections
 import os.path
-import socket
 import yaml
 
 
@@ -56,7 +55,7 @@ class Data(object):
             'storage_middleware_version': 'v1.0',
             'storage_total_storage': 0,
             'storage_service_production_level': 'production',
-            'storage_service_name': socket.getfqdn(),
+            'storage_service_name': 'example.org',
         }
 
     @property
@@ -77,7 +76,7 @@ class Data(object):
             'compute_total_cores': 0,
             'compute_total_ram': 0,
             'compute_service_production_level': 'production',
-            'compute_service_name': socket.getfqdn(),
+            'compute_service_name': 'example.org',
             'endpoints': {
                 'https://cloud-service01.example.org:8787': {
                     'compute_endpoint_url':

--- a/cloud_info_provider/tests/test_openstack.py
+++ b/cloud_info_provider/tests/test_openstack.py
@@ -23,7 +23,6 @@ class OpenStackProviderOptionsTest(base.TestCase):
                                   '--os-auth-url', 'http://example.org:5000',
                                   '--os-cacert', 'foobar',
                                   '--insecure',
-                                  '--legacy-occi-os',
                                   '--all-images',
                                   '--select-flavors', 'public'])
 
@@ -32,7 +31,6 @@ class OpenStackProviderOptionsTest(base.TestCase):
         self.assertEqual(opts.os_auth_url, 'http://example.org:5000')
         self.assertEqual(opts.os_cacert, 'foobar')
         self.assertEqual(opts.insecure, True)
-        self.assertEqual(opts.legacy_occi_os, True)
         self.assertEqual(opts.all_images, True)
         self.assertEqual(opts.select_flavors, 'public')
 
@@ -57,7 +55,6 @@ class OpenStackProviderTest(base.TestCase):
                 self.auth_plugin = mock.MagicMock()
                 self.auth_plugin.auth_url = 'http://foo.example.org:5000/v2'
                 self.static = mock.Mock()
-                self.legacy_occi_os = False
                 self.keystone_cert_issuer = "foo"
                 self.keystone_trusted_cas = []
                 self.insecure = False
@@ -80,124 +77,6 @@ class OpenStackProviderTest(base.TestCase):
             self.assertDictEqual(expected[k], v)
             for f in fields:
                 self.assertIn(f, v)
-
-    def test_get_legacy_templates_with_defaults(self):
-        expected_templates = {}
-        url = 'http://schemas.openstack.org/template/resource'
-        for f in FAKES.flavors:
-            name = f.name.strip().replace(' ', '_').replace('.', '-').lower()
-            expected_templates[f.id] = {
-                'template_memory': f.ram,
-                'template_cpu': f.vcpus,
-                'template_id': '%s#%s' % (url, name),
-                'template_native_id': "%s" % f.name,
-                'template_platform': 'amd64',
-                'template_network': 'private',
-                'template_disk': f.disk,
-                'template_ephemeral': f.ephemeral,
-            }
-
-        self.provider.legacy_occi_os = True
-        with utils.nested(
-                mock.patch.object(self.provider.static,
-                                  'get_template_defaults'),
-                mock.patch.object(self.provider.nova.flavors, 'list'),
-        ) as (m_get_template_defaults, m_flavors_list):
-            m_get_template_defaults.return_value = {}
-            m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
-            assert m_get_template_defaults.called
-
-        self.assert_resources(expected_templates,
-                              templates,
-                              template="compute.ldif",
-                              ignored_fields=[
-                                  "compute_api_type",
-                                  "compute_api_version",
-                                  "compute_api_endpoint_technology",
-                                  "compute_capabilities",
-                                  "compute_endpoint_url",
-                                  "compute_hypervisor",
-                                  "compute_hypervisor_version",
-                                  "compute_middleware",
-                                  "compute_middleware_developer",
-                                  "compute_middleware_version",
-                                  "compute_production_level",
-                                  "compute_api_authn_method",
-                                  "compute_service_name",
-                                  "compute_service_production_level",
-                                  "compute_total_cores",
-                                  "compute_total_ram",
-                                  "image_id",
-                                  "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version",
-                                  "image_description",
-                                  "image_marketplace_id"
-                              ])
-
-    def test_get_legacy_templates_with_defaults_from_static(self):
-        expected_templates = {}
-        url = 'http://schemas.openstack.org/template/resource'
-        for f in FAKES.flavors:
-            name = f.name.strip().replace(' ', '_').replace('.', '-').lower()
-            expected_templates[f.id] = {
-                'template_memory': f.ram,
-                'template_cpu': f.vcpus,
-                'template_id': '%s#%s' % (url, name),
-                'template_native_id': "%s" % f.name,
-                'template_platform': 'i686',
-                'template_network': 'private',
-                'template_disk': f.disk,
-                'template_ephemeral': f.ephemeral,
-            }
-
-        self.provider.legacy_occi_os = True
-        with utils.nested(
-                mock.patch.object(self.provider.static,
-                                  'get_template_defaults'),
-                mock.patch.object(self.provider.nova.flavors, 'list'),
-        ) as (m_get_template_defaults, m_flavors_list):
-            m_get_template_defaults.return_value = {
-                'template_platform': 'i686'
-            }
-            m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
-            assert m_get_template_defaults.called
-
-        self.assert_resources(expected_templates,
-                              templates,
-                              template="compute.ldif",
-                              ignored_fields=[
-                                  "compute_api_type",
-                                  "compute_api_version",
-                                  "compute_api_endpoint_technology",
-                                  "compute_capabilities",
-                                  "compute_endpoint_url",
-                                  "compute_hypervisor",
-                                  "compute_hypervisor_version",
-                                  "compute_middleware",
-                                  "compute_middleware_developer",
-                                  "compute_middleware_version",
-                                  "compute_production_level",
-                                  "compute_api_authn_method",
-                                  "compute_service_name",
-                                  "compute_service_production_level",
-                                  "compute_total_cores",
-                                  "compute_total_ram",
-                                  "image_id",
-                                  "image_name",
-                                  "image_os_family",
-                                  "image_os_name",
-                                  "image_os_version",
-                                  "image_platform",
-                                  "image_version",
-                                  "image_description",
-                                  "image_marketplace_id"
-                              ])
 
     def test_get_templates_with_defaults(self):
         expected_templates = {}
@@ -546,7 +425,7 @@ class OpenStackProviderTest(base.TestCase):
                 'image_platform': 'amd64',
                 'image_version': None,
                 'image_marketplace_id': 'http://example.org/',
-                'image_id': 'http://schemas.openstack.org/template/os#foo-id',
+                'image_id': 'http://schemas.openstack.org/template/os#foo.id',
                 'image_native_id': 'foo.id',
                 'image_accel_type': None,
                 'image_access_info': 'none',
@@ -658,11 +537,6 @@ class OpenStackProviderTest(base.TestCase):
     def test_get_endpoints_with_defaults_from_static(self):
         expected_endpoints = {
             'endpoints': {
-                'https://cloud.example.org:8787/': {
-                    'compute_api_type': 'OCCI',
-                    'compute_api_version': '11.11',
-                    'compute_endpoint_id': '03e087c8fb3b495c9a360bcba3abf914',
-                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
                 'http://foo.example.org:5000/v2': {
                     'compute_api_type': 'OpenStack',
                     # As version is extracted from the URL default is not used
@@ -698,16 +572,6 @@ class OpenStackProviderTest(base.TestCase):
     def test_get_endpoints_with_defaults(self):
         expected_endpoints = {
             'endpoints': {
-                'https://cloud.example.org:8787/': {
-                    'compute_api_type': 'OCCI',
-                    'compute_api_version': 'UNKNOWN',
-                    'compute_middleware': 'ooi',
-                    'compute_middleware_version': 'UNKNOWN',
-                    'compute_middleware_developer': 'CSIC',
-                    'endpoint_issuer': self.provider.keystone_cert_issuer,
-                    'endpoint_trusted_cas': [],
-                    'compute_endpoint_id': '03e087c8fb3b495c9a360bcba3abf914',
-                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
                 'http://foo.example.org:5000/v2': {
                     'compute_api_type': 'OpenStack',
                     'compute_api_version': 'v2',
@@ -739,6 +603,247 @@ class OpenStackProviderTest(base.TestCase):
         self.assertDictEqual(expected_endpoints, endpoints)
 
     def test_occify_terms(self):
-        self.assertEqual('m1-tiny', self.provider.occify('m1.tiny'))
-        self.assertEqual('m1_tiny', self.provider.occify('m1 tiny'))
-        self.assertEqual('m1-tiny_s', self.provider.occify('m1.tiny s'))
+        self.assertEqual('m1.tiny', self.provider.adapt_id('m1.tiny'))
+        self.assertEqual('m1 tiny', self.provider.adapt_id('m1 tiny'))
+        self.assertEqual('m1.tiny s', self.provider.adapt_id('m1.tiny s'))
+
+    def test_service_type(self):
+        self.assertEqual('compute', self.provider.service_type)
+
+
+class OoiProviderTest(OpenStackProviderTest):
+    def setUp(self):
+        super(OoiProviderTest, self).setUp()
+
+        class FakeProvider(os_provider.OoiProvider):
+            def __init__(self, opts):
+                self.nova = mock.Mock()
+                self.glance = mock.Mock()
+                self.glance.http_client.get_endpoint.return_value = (
+                    "http://glance.example.org:9292/v2"
+                )
+                self.session = mock.Mock()
+                self.session.get_project_id.return_value = 'TEST_PROJECT_ID'
+                self.auth_plugin = mock.MagicMock()
+                self.auth_plugin.auth_url = 'http://foo.example.org:5000/v2'
+                self.static = mock.Mock()
+                self.keystone_cert_issuer = "foo"
+                self.keystone_trusted_cas = []
+                self.insecure = False
+                self.os_cacert = '/etc/ssl/cas'
+                self.os_project_id = None
+                self.select_flavors = 'all'
+                self._rescope_project = mock.Mock()
+                self.all_images = False
+
+        self.provider = FakeProvider(None)
+
+    def test_occify_terms(self):
+        self.assertEqual('m1-tiny', self.provider.adapt_id('m1.tiny'))
+        self.assertEqual('m1_tiny', self.provider.adapt_id('m1 tiny'))
+        self.assertEqual('m1-tiny_s', self.provider.adapt_id('m1.tiny s'))
+
+    def test_service_type(self):
+        self.assertEqual('occi', self.provider.service_type)
+
+    def test_get_images(self):
+        # XXX move this to a custom class?
+        # XXX add docker information
+        expected_images = {
+            'bar id': {
+                'name': 'barimage',
+                'id': 'bar id',
+                'metadata': {},
+                'file': 'v2/bar id/file',
+                'image_description': None,
+                'image_name': 'barimage',
+                'image_os_family': None,
+                'image_os_name': None,
+                'image_os_version': None,
+                'image_platform': 'amd64',
+                'image_version': None,
+                'image_marketplace_id': "%s" % urljoin(self.provider.glance
+                                                       .http_client
+                                                       .get_endpoint(),
+                                                       'v2/bar id/file'),
+                'image_id': 'http://schemas.openstack.org/template/os#bar_id',
+                'image_native_id': 'bar id',
+                'image_accel_type': None,
+                'image_access_info': 'none',
+                'image_minimal_cpu': None,
+                'image_minimal_ram': None,
+                'image_minimal_accel': None,
+                'image_recommended_cpu': None,
+                'image_recommended_ram': None,
+                'image_recommended_accel': None,
+                'image_size': None,
+                'image_software': [],
+                'image_traffic_in': [],
+                'image_traffic_out': [],
+                'image_context_format': None,
+            },
+            'foo.id': {
+                'name': 'fooimage',
+                'id': 'foo.id',
+                'metadata': {},
+                'marketplace': 'http://example.org/',
+                'file': 'v2/foo.id/file',
+                'image_description': None,
+                'image_name': 'fooimage',
+                'image_os_family': None,
+                'image_os_name': None,
+                'image_os_version': None,
+                'image_platform': 'amd64',
+                'image_version': None,
+                'image_marketplace_id': 'http://example.org/',
+                'image_id': 'http://schemas.openstack.org/template/os#foo-id',
+                'image_native_id': 'foo.id',
+                'image_accel_type': None,
+                'image_access_info': 'none',
+                'image_minimal_cpu': None,
+                'image_minimal_ram': None,
+                'image_minimal_accel': None,
+                'image_recommended_cpu': None,
+                'image_recommended_ram': None,
+                'image_recommended_accel': None,
+                'image_size': None,
+                'image_software': [],
+                'image_traffic_in': [],
+                'image_traffic_out': [],
+                'image_context_format': None,
+            },
+            'baz id': {
+                'name': 'bazimage',
+                'id': 'baz id',
+                'file': 'v2/baz id/file',
+                'image_description': None,
+                'image_name': 'bazimage',
+                'image_os_family': None,
+                'image_os_name': None,
+                'image_os_version': None,
+                'image_platform': 'amd64',
+                'image_version': None,
+                'image_marketplace_id': "%s" % urljoin(self.provider.glance
+                                                       .http_client
+                                                       .get_endpoint(),
+                                                       'v2/baz id/file'),
+                'image_id': 'http://schemas.openstack.org/template/os#baz_id',
+                'image_native_id': 'baz id',
+                'docker_id': 'sha1:xxxxxxxxxxxxxxxxxxxxxxxxxx',
+                'docker_tag': 'latest',
+                'docker_name': 'test/image',
+                'image_accel_type': None,
+                'image_access_info': 'none',
+                'image_minimal_cpu': None,
+                'image_minimal_ram': None,
+                'image_minimal_accel': None,
+                'image_recommended_cpu': None,
+                'image_recommended_ram': None,
+                'image_recommended_accel': None,
+                'image_size': None,
+                'image_software': [],
+                'image_traffic_in': [],
+                'image_traffic_out': [],
+                'image_context_format': None,
+            }
+        }
+
+        with utils.nested(
+                mock.patch.object(self.provider.static, 'get_image_defaults'),
+                mock.patch.object(self.provider.glance.images, 'list'),
+        ) as (m_get_image_defaults, m_images_list):
+            m_get_image_defaults.return_value = {}
+            m_images_list.return_value = FAKES.images
+
+            images = self.provider.get_images()
+            assert m_get_image_defaults.called
+
+        # Filter fields from the template that are not related to images
+        self.assert_resources(expected_images,
+                              images,
+                              template="compute.ldif",
+                              ignored_fields=["compute_service_name",
+                                              "compute_api_type",
+                                              "compute_api_version",
+                                              ("compute_api_endpoint"
+                                               "_technology"),
+                                              "compute_capabilities",
+                                              "compute_api_authn_method",
+                                              "compute_total_ram",
+                                              "compute_middleware",
+                                              "compute_middleware_developer",
+                                              "compute_middleware_version",
+                                              "compute_endpoint_url",
+                                              "compute_hypervisor",
+                                              "compute_hypervisor_version",
+                                              "compute_production_level",
+                                              ("compute_service"
+                                               "_production_level"),
+                                              "compute_total_cores",
+                                              "compute_total_ram",
+                                              "template_platform",
+                                              "template_cpu",
+                                              "template_memory",
+                                              "template_network",
+                                              "template_disk",
+                                              "template_ephemeral",
+                                              "template_id"])
+
+    def test_get_endpoints_with_defaults_from_static(self):
+        expected_endpoints = {
+            'endpoints': {
+                'https://cloud.example.org:8787/': {
+                    'compute_api_type': 'OCCI',
+                    'compute_api_version': '11.11',
+                    'compute_endpoint_id': '03e087c8fb3b495c9a360bcba3abf914',
+                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
+            },
+            'compute_middleware_developer': 'OpenStack',
+            'compute_middleware': 'OpenStack Nova',
+            'compute_service_name': 'http://foo.example.org:5000/v2',
+        }
+
+        with mock.patch.object(
+                self.provider.static, 'get_compute_endpoint_defaults'
+        ) as m_get_endpoint_defaults:
+            m_get_endpoint_defaults.return_value = {
+                'compute_occi_api_version': '11.11',
+                'compute_compute_api_version': '99.99',
+            }
+            r = mock.Mock()
+            r.service_catalog = FAKES.catalog
+            self.provider.auth_plugin.get_access.return_value = r
+            endpoints = self.provider.get_compute_endpoints()
+            assert m_get_endpoint_defaults.called
+
+        for k, v in expected_endpoints['endpoints'].items():
+            self.assertDictContainsSubset(v, endpoints['endpoints'].get(k, {}))
+
+    def test_get_endpoints_with_defaults(self):
+        expected_endpoints = {
+            'endpoints': {
+                'https://cloud.example.org:8787/': {
+                    'compute_api_type': 'OCCI',
+                    'compute_api_version': 'UNKNOWN',
+                    'compute_middleware': 'ooi',
+                    'compute_middleware_version': 'UNKNOWN',
+                    'compute_middleware_developer': 'CSIC',
+                    'endpoint_issuer': self.provider.keystone_cert_issuer,
+                    'endpoint_trusted_cas': [],
+                    'compute_endpoint_id': '03e087c8fb3b495c9a360bcba3abf914',
+                    'compute_endpoint_url': 'https://cloud.example.org:8787/'},
+            },
+            'compute_service_name': 'http://foo.example.org:5000/v2',
+        }
+
+        with mock.patch.object(
+                self.provider.static, 'get_compute_endpoint_defaults'
+        ) as m_get_endpoint_defaults:
+            m_get_endpoint_defaults.return_value = {}
+            r = mock.Mock()
+            r.service_catalog = FAKES.catalog
+            self.provider.auth_plugin.get_access.return_value = r
+            endpoints = self.provider.get_compute_endpoints()
+            assert m_get_endpoint_defaults.called
+
+        self.assertDictEqual(expected_endpoints, endpoints)

--- a/cloud_info_provider/tests/test_static.py
+++ b/cloud_info_provider/tests/test_static.py
@@ -221,7 +221,9 @@ class StaticProviderTest(base.TestCase):
 
     def test_get_storage_endpoints(self):
         expected = DATA.storage_endpoints
-        self.assertEqual(expected, self.provider.get_storage_endpoints())
+        with mock.patch('socket.getfqdn') as m_fqdn:
+            m_fqdn.return_value = 'example.org'
+            self.assertEqual(expected, self.provider.get_storage_endpoints())
 
     def test_get_compute_endpoints(self):
         expected = DATA.compute_endpoints
@@ -232,7 +234,9 @@ class StaticProviderTest(base.TestCase):
             'compute_cpu_virt_type': None,
             'compute_virtual_disk_formats': None,
         })
-        self.assertEqual(expected, self.provider.get_compute_endpoints())
+        with mock.patch('socket.getfqdn') as m_fqdn:
+            m_fqdn.return_value = 'example.org'
+            self.assertEqual(expected, self.provider.get_compute_endpoints())
 
     def test_no_site_name(self):
         self.opts.glite_site_info_static = "This does not exist"


### PR DESCRIPTION
<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 

This moves the OCCI-specific code of the OpenStack provider to a new ooi provider. This will allow to easily support antive OpenStack without OCCI and to adapt to publishing to AMS using independent topics for each service endpoint in GOCDB.

<!-- Describe in plain English what this PR does -->

