### PR TITLE
Fix: session credentials for project rescoping

### DIFF
--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -49,8 +49,8 @@ logging.getLogger('keystoneclient').setLevel(logging.WARNING)
 # TODO(enolfc): should this be completely inside the provider class?
 def _rescope(f):
     @functools.wraps(f)
-    def inner(self, project=None, **kwargs):
-        self._rescope_project(project)
+    def inner(self, project=None, project_domain_name=None, **kwargs):
+        self._rescope_project(project, project_domain_name)
         return f(self, **kwargs)
     return inner
 
@@ -96,7 +96,8 @@ class OpenStackProvider(providers.BaseProvider):
         self.glance = glanceclient.Client('2', session=self.session)
 
         try:
-            self.project = self.session.get_project_id()
+            self.project_id = self.session.get_project_id()
+            self.project = self.session.auth.project_name
         except http_exc.Unauthorized:
             msg = "Could not authorize user"
             raise exceptions.OpenStackProviderException(msg)
@@ -115,15 +116,16 @@ class OpenStackProvider(providers.BaseProvider):
         # Select 'public', 'private' or 'all' (default) templates.
         self.select_flavors = opts.select_flavors
 
-    def _rescope_project(self, project):
+    def _rescope_project(self, project, project_domain_name):
         '''Switch to new OS project whenever there is a change.
 
            It updates every OpenStack client used in case of new project.
         '''
         if (not self.project or project != self.project):
-            self.opts.os_project_id = project
+            self.opts.os_project_name = project
+            self.opts.os_project_domain_name = project_domain_name
             # make sure that it also works for v2voms
-            self.opts.os_tenant_id = project
+            self.opts.os_tenant_name = project
             self.auth_plugin = loading.load_auth_from_argparse_arguments(
                 self.opts
             )
@@ -132,7 +134,8 @@ class OpenStackProvider(providers.BaseProvider):
             )
             self.auth_plugin.invalidate()
             try:
-                self.project = self.session.get_project_id()
+                self.project_id = self.session.get_project_id()
+                self.project = project
             except http_exc.Unauthorized:
                 msg = "Could not authorize user in project '%s'" % project
                 raise exceptions.OpenStackProviderException(msg)
@@ -348,7 +351,7 @@ class OpenStackProvider(providers.BaseProvider):
         quotas = defaults.copy()
 
         try:
-            project_quotas = self.nova.quotas.get(self.project)
+            project_quotas = self.nova.quotas.get(self.project_id)
             for resource in quota_resources:
                 try:
                     quotas[resource] = getattr(project_quotas, resource)

--- a/cloud_info_provider/providers/static.py
+++ b/cloud_info_provider/providers/static.py
@@ -131,7 +131,8 @@ class StaticProvider(providers.BaseProvider):
     def get_compute_shares(self, **kwargs):
         fields = ('instance_max_cpu', 'instance_max_ram',
                   'instance_max_accelerators',
-                  'project', 'sla', 'network_info', 'membership')
+                  'project', 'project_domain_name',
+                  'sla', 'network_info', 'membership')
         shares = self._get_what('compute',
                                 'shares',
                                 None,

--- a/etc/sample.openstack.yaml
+++ b/etc/sample.openstack.yaml
@@ -73,6 +73,8 @@ compute:
         ops:
             # the project id in OpenStack
             project: ops_xxxxx
+            # the domain where the project belongs to
+            project_domain_name: default
             # link to the SLA document
             sla: UNKNOWN
             # Type of network: infiniband, gigabiteethernet...
@@ -82,6 +84,7 @@ compute:
             #     - VO:ops
         fedcloud.egi.eu:
             project: fedcloud_xxxx
+            project_domain_name: default
             sla: https://egi.eu/sla/fedcloud
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN
@@ -89,6 +92,8 @@ compute:
                 - VOMS:/fedcloud.egi.eu/Role=VMOperators
         training.egi.eu:
             project: xxxxx_training
+            project_domain_name: default
+            sla: https://egi.eu/sla/fedcloud
             sla: https://egi.eu/sla/training
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN


### PR DESCRIPTION
<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 
This is a fix for OpenStack provider that sets the correct/required project and domain name in the keystoneauth's session object, in order to successfully authenticate with the API. The project's domain name needs to be added to the static YAML's configuration. Here `project_domain_name` was used.

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue :** #117 

