### PR TITLE
Make the usage of project ID more clear in code and configuration files

### DIFF
--- a/cloud_info_provider/providers/opennebula.py
+++ b/cloud_info_provider/providers/opennebula.py
@@ -88,7 +88,7 @@ class OpenNebulaBaseProvider(providers.BaseProvider):
         }
         defaults = self.static.get_image_defaults(prefix=True)
         img_schema = defaults.get('image_schema', 'template')
-        group_name = kwargs.get('auth', {}).get('project_id', None)
+        group_name = kwargs.get('auth', {}).get('group', None)
 
         templates = {}
         for tpl_id, tpl in self._get_one_templates().items():
@@ -215,7 +215,7 @@ class OpenNebulaROCCIProvider(OpenNebulaBaseProvider):
         template.update(self.static.get_template_defaults(prefix=True))
 
         if self.rocci_remote_templates:
-            group_name = kwargs.get('auth', {}).get('project_id', None)
+            group_name = kwargs.get('auth', {}).get('group', None)
             templates = self.remote_templates(template, group_name)
         else:
             templates = self.local_templates(template)

--- a/cloud_info_provider/providers/opennebula.py
+++ b/cloud_info_provider/providers/opennebula.py
@@ -88,7 +88,7 @@ class OpenNebulaBaseProvider(providers.BaseProvider):
         }
         defaults = self.static.get_image_defaults(prefix=True)
         img_schema = defaults.get('image_schema', 'template')
-        group_name = kwargs.get('project', None)
+        group_name = kwargs.get('auth', {}).get('project_id', None)
 
         templates = {}
         for tpl_id, tpl in self._get_one_templates().items():
@@ -215,7 +215,7 @@ class OpenNebulaROCCIProvider(OpenNebulaBaseProvider):
         template.update(self.static.get_template_defaults(prefix=True))
 
         if self.rocci_remote_templates:
-            group_name = kwargs.get('project', None)
+            group_name = kwargs.get('auth', {}).get('project_id', None)
             templates = self.remote_templates(template, group_name)
         else:
             templates = self.local_templates(template)

--- a/cloud_info_provider/providers/static.py
+++ b/cloud_info_provider/providers/static.py
@@ -137,14 +137,6 @@ class StaticProvider(providers.BaseProvider):
                                 None,
                                 fields,
                                 prefix='')
-        # if there is no explicit membership defined, assume VO:<nameofshare>
-        # also if there is no "project" defined, assume VO following
-        # rOCCI convention: group name == VO name
-        for vo, share in shares['shares'].items():
-            if not share['membership']:
-                share['membership'] = ["VO:%s" % vo]
-            if not share['auth']['project_id']:
-                share['auth']['project_id'] = vo
         return shares['shares']
 
     def get_compute_quotas(self, **kwargs):

--- a/cloud_info_provider/providers/static.py
+++ b/cloud_info_provider/providers/static.py
@@ -131,7 +131,7 @@ class StaticProvider(providers.BaseProvider):
     def get_compute_shares(self, **kwargs):
         fields = ('instance_max_cpu', 'instance_max_ram',
                   'instance_max_accelerators',
-                  'project', 'sla', 'network_info', 'membership')
+                  'auth', 'sla', 'network_info', 'membership')
         shares = self._get_what('compute',
                                 'shares',
                                 None,
@@ -143,8 +143,8 @@ class StaticProvider(providers.BaseProvider):
         for vo, share in shares['shares'].items():
             if not share['membership']:
                 share['membership'] = ["VO:%s" % vo]
-            if not share['project']:
-                share['project'] = vo
+            if not share['auth']['project_id']:
+                share['auth']['project_id'] = vo
         return shares['shares']
 
     def get_compute_quotas(self, **kwargs):

--- a/cloud_info_provider/tests/data.py
+++ b/cloud_info_provider/tests/data.py
@@ -173,11 +173,15 @@ class Data(object):
         return {
             'fedcloud.egi.eu': {
                 'sla': 'https://egi.eu/sla/fedcloud',
-                'project': 'fedcloud',
+                'auth': {
+                    'project_id': 'fedcloud',
+                }
             },
             'training.egi.eu': {
                 'sla': 'https://egi.eu/sla/training',
-                'project': 'training',
+                'auth': {
+                    'project_id': 'training',
+                }
             },
         }
 

--- a/cloud_info_provider/tests/test_openstack.py
+++ b/cloud_info_provider/tests/test_openstack.py
@@ -93,7 +93,6 @@ class OpenStackProviderTest(base.TestCase):
                 'template_disk': f.disk,
                 'template_ephemeral': f.ephemeral,
             }
-
         with utils.nested(
                 mock.patch.object(self.provider.static,
                                   'get_template_defaults'),
@@ -101,9 +100,9 @@ class OpenStackProviderTest(base.TestCase):
         ) as (m_get_template_defaults, m_flavors_list):
             m_get_template_defaults.return_value = {}
             m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
+            templates = self.provider.get_templates(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_template_defaults.called)
-
         self.assert_resources(expected_templates,
                               templates,
                               template="compute.ldif",
@@ -159,7 +158,8 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
+            templates = self.provider.get_templates(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_template_defaults.called)
 
         self.assert_resources(expected_templates,
@@ -215,7 +215,8 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
+            templates = self.provider.get_templates(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_template_defaults.called)
 
         # Extract required fields from compute.ldif template excluding fields
@@ -277,7 +278,8 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
+            templates = self.provider.get_templates(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_template_defaults.called)
 
         # Extract required fields from compute.ldif template excluding fields
@@ -339,7 +341,8 @@ class OpenStackProviderTest(base.TestCase):
                 'template_platform': 'i686'
             }
             m_flavors_list.return_value = FAKES.flavors
-            templates = self.provider.get_templates()
+            templates = self.provider.get_templates(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_template_defaults.called)
 
         # Extract required fields from compute.ldif template excluding fields
@@ -485,7 +488,7 @@ class OpenStackProviderTest(base.TestCase):
             m_get_image_defaults.return_value = {}
             m_images_list.return_value = FAKES.images
 
-            images = self.provider.get_images()
+            images = self.provider.get_images(**{'auth': {'project_id': None}})
             self.assertTrue(m_get_image_defaults.called)
 
         # Filter fields from the template that are not related to images
@@ -530,7 +533,7 @@ class OpenStackProviderTest(base.TestCase):
             m_get_image_defaults.return_value = {}
             m_images_list.return_value = FAKES.images
 
-            images = self.provider.get_images()
+            images = self.provider.get_images(**{'auth': {'project_id': None}})
             self.assertTrue(m_get_image_defaults.called)
 
         self.assertItemsEqual(images.keys(), expected_images)
@@ -564,7 +567,8 @@ class OpenStackProviderTest(base.TestCase):
             r = mock.Mock()
             r.service_catalog = FAKES.catalog
             self.provider.auth_plugin.get_access.return_value = r
-            endpoints = self.provider.get_compute_endpoints()
+            endpoints = self.provider.get_compute_endpoints(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_endpoint_defaults.called)
 
         for k, v in expected_endpoints['endpoints'].items():
@@ -598,7 +602,8 @@ class OpenStackProviderTest(base.TestCase):
             r = mock.Mock()
             r.service_catalog = FAKES.catalog
             self.provider.auth_plugin.get_access.return_value = r
-            endpoints = self.provider.get_compute_endpoints()
+            endpoints = self.provider.get_compute_endpoints(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_endpoint_defaults.called)
 
         self.assertDictEqual(expected_endpoints, endpoints)
@@ -756,7 +761,7 @@ class OoiProviderTest(OpenStackProviderTest):
             m_get_image_defaults.return_value = {}
             m_images_list.return_value = FAKES.images
 
-            images = self.provider.get_images()
+            images = self.provider.get_images(**{'auth': {'project_id': None}})
             self.assertTrue(m_get_image_defaults.called)
 
         # Filter fields from the template that are not related to images
@@ -814,7 +819,8 @@ class OoiProviderTest(OpenStackProviderTest):
             r = mock.Mock()
             r.service_catalog = FAKES.catalog
             self.provider.auth_plugin.get_access.return_value = r
-            endpoints = self.provider.get_compute_endpoints()
+            endpoints = self.provider.get_compute_endpoints(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_endpoint_defaults.called)
 
         for k, v in expected_endpoints['endpoints'].items():
@@ -844,7 +850,8 @@ class OoiProviderTest(OpenStackProviderTest):
             r = mock.Mock()
             r.service_catalog = FAKES.catalog
             self.provider.auth_plugin.get_access.return_value = r
-            endpoints = self.provider.get_compute_endpoints()
+            endpoints = self.provider.get_compute_endpoints(**{
+                'auth': {'project_id': None}})
             self.assertTrue(m_get_endpoint_defaults.called)
 
         self.assertDictEqual(expected_endpoints, endpoints)

--- a/etc/sample.opennebula.yaml
+++ b/etc/sample.opennebula.yaml
@@ -87,11 +87,11 @@ compute:
     shares:
         # the vo name
         ops:
-            #auth:
-            #   # Group name in OpenNebula, default is equal to share name
-            #   group: xxxxx
+            auth:
+               # Group name in OpenNebula, default is equal to share name
+               group: ops
             # Link to the VO SLA
-            #sla: UNKNOWN
+            sla: UNKNOWN
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN
             # Default membership is VO:<share name>, specify if finer grained AuthZ is used

--- a/etc/sample.opennebula.yaml
+++ b/etc/sample.opennebula.yaml
@@ -87,8 +87,9 @@ compute:
     shares:
         # the vo name
         ops:
-            # Group name in OpenNebula, default is equal to share name
-            #project: ops
+            #auth:
+            #   # Group name in OpenNebula, default is equal to share name
+            #   group: xxxxx
             # Link to the VO SLA
             #sla: UNKNOWN
             # Type of network: infiniband, gigabiteethernet...

--- a/etc/sample.opennebularocci.yaml
+++ b/etc/sample.opennebularocci.yaml
@@ -84,21 +84,24 @@ compute:
 
     shares:
         ops:
-            project: ops
+            auth:
+                group: ops
             sla: UNKNOWN
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN
             membership:
                 - VO:ops
         fedcloud.egi.eu:
-            project: fedcloud
+            auth:
+                group: fedcloud
             sla: https://egi.eu/sla/fedcloud
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN
             membership:
                 - VOMS:/fedcloud.egi.eu/Role=VMOperators
         training.egi.eu:
-            project: training
+            auth:
+                group: training
             sla: https://egi.eu/sla/training
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN

--- a/etc/sample.openstack.yaml
+++ b/etc/sample.openstack.yaml
@@ -71,8 +71,9 @@ compute:
     shares:
         # Name of the VO
         ops:
-            # the project id in OpenStack
-            project: ops_xxxxx
+            auth:
+                # the project id in OpenStack
+                project_id: xxxxx
             # link to the SLA document
             sla: UNKNOWN
             # Type of network: infiniband, gigabiteethernet...
@@ -81,14 +82,16 @@ compute:
             # membership:
             #     - VO:ops
         fedcloud.egi.eu:
-            project: fedcloud_xxxx
+            auth:
+                project_id: xxxx
             sla: https://egi.eu/sla/fedcloud
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN
             membership:
                 - VOMS:/fedcloud.egi.eu/Role=VMOperators
         training.egi.eu:
-            project: xxxxx_training
+            auth:
+                project_id: xxxxx
             sla: https://egi.eu/sla/training
             # Type of network: infiniband, gigabiteethernet...
             network_info: UNKNOWN


### PR DESCRIPTION
<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 

<!-- Describe in plain English what this PR does -->
This change tries to make more clear the usage of project ID in the configuration. The layout has been slightly modified so the `project_id` attribute falls under the `auth` category. In addition, the variables used in the code now refer to `project_id` (instead of the former `project`).

Closes #118 

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue : #117 **

