### PR TITLE
Use 443 port as default for https

### DIFF
--- a/cloud_info_provider/providers/ssl_utils.py
+++ b/cloud_info_provider/providers/ssl_utils.py
@@ -34,6 +34,10 @@ def get_endpoint_ca_information(endpoint_url, insecure=False, cafile=None,
     if scheme != 'https':
         return ca_info
 
+    # use default port for https
+    if not port:
+        port = 443
+
     try:
         ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.set_options(SSL.OP_NO_SSLv2)


### PR DESCRIPTION

<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 

Use default port 443 for SSL checks when not specified in the URL of the cloud middleware


<!-- Describe in plain English what this PR does -->

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue :** #140 

