### PR TITLE
Pythonize only for Ruby dict-like strings

### DIFF
--- a/cloud_info_provider/utils.py
+++ b/cloud_info_provider/utils.py
@@ -33,5 +33,8 @@ def get_tag_value(xml, tag):
 
 
 def pythonize_network_info(network_info):
-    '''Pythonize network_info string'''
-    return json.loads(network_info.replace(':"', '"').replace("=>", ":"))
+    '''Pythonize Ruby dict-like network_info string. Do nothing otherwise.'''
+    try:
+        return json.loads(network_info.replace(':"', '"').replace("=>", ":"))
+    except AttributeError:
+        return network_info


### PR DESCRIPTION
<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

## Summary 

[atrope](https://github.com/alvarolopez/atrope) already adds JSON compliant values for `ad:traffic_in` and `ad:traffic_out` appliance attributes for glance images, thus `pythonize_network_info` should not be applied in this case.


