### PR TITLE
Fix get instances for volume-based instances

### DIFF
--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -353,7 +353,7 @@ class OpenStackProvider(providers.BaseProvider):
 
         for instance in self.nova.servers.list():
             ret = instance_template.copy()
-            if type(instance.image) == dict:
+            if isinstance(instance.image, dict):
                 image_id = instance.image.get('id', '')
             else:
                 image_id = instance.image

--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -353,10 +353,14 @@ class OpenStackProvider(providers.BaseProvider):
 
         for instance in self.nova.servers.list():
             ret = instance_template.copy()
+            if type(instance.image) == dict:
+                image_id = instance.image.get('id', '')
+            else:
+                image_id = instance.image
             ret.update({
                 'instance_name': instance.name,
-                'instance_image_id': instance.image['id'],
-                'instance_template_id': instance.flavor['id'],
+                'instance_image_id': image_id,
+                'instance_template_id': instance.flavor.get('id', ''),
                 'instance_status': instance.status,
             })
             instances[instance.id] = ret


### PR DESCRIPTION

<!--  
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as 
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary 

Fix the case when the instance is started from a Volume as OpenStack returns an empty-string in this case, instead of a dict with the image details.
<!-- Describe in plain English what this PR does -->

